### PR TITLE
[Fix] 카드 스크롤 뷰 버그 수정

### DIFF
--- a/WorkUp/WorkUp/View/CardDetail/CardDetailView.swift
+++ b/WorkUp/WorkUp/View/CardDetail/CardDetailView.swift
@@ -31,6 +31,20 @@ struct CardDetailView: View {
             Color.black
                 .ignoresSafeArea(.all)
             
+            HStack {
+                Spacer()
+                
+                Button(action: {
+                    self.presentationMode.wrappedValue.dismiss()
+                }, label: {
+                    Image("Close")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 35, height: 35)
+                })
+                .padding(.trailing, 23)
+            }
+            
             VStack(spacing: 0) {
                 
                 setHeaderView()
@@ -41,7 +55,7 @@ struct CardDetailView: View {
                             ForEach(shuffledCardList.indices, id: \.self) { idx in
                                 if motionMode == .top {
                                     RollMotionCardView(motionManager: motionManager, currentIndex: $currentIndex, shuffledCardList: shuffledCardList)
-                                       
+                                    
                                 } else {
                                     YawMotionCardView(motionManager: motionManager, currentIndex: $currentIndex, shuffledCardList: shuffledCardList, isLeft: motionMode == .left ? true : false)
                                 }
@@ -69,8 +83,8 @@ struct CardDetailView: View {
                     .scrollDisabled(motionManager.isDeviceFlipped ? true : false)
                     .scrollDisabled(motionManager.isYawRotated ? true : false)
                 }
-
-               
+                
+                
                 if motionMode == .top && motionManager.isDeviceFlipped && !motionManager.isDeviceFlippedFor5Seconds {
                     VStack(spacing: 0) {
                         Text("내용 확인하기")
@@ -81,7 +95,7 @@ struct CardDetailView: View {
                             .multilineTextAlignment(.center)
                             .padding(.top, 19)
                     }
-                    .offset(y: -50)
+                    .offset(y: -80)
                     
                 } else if motionMode == .top && motionManager.isDeviceFlipped && motionManager.isDeviceFlippedFor5Seconds {
                     
@@ -90,7 +104,7 @@ struct CardDetailView: View {
                         .scaledToFit()
                         .frame(width: 106, height: 155)
                         .rotationEffect(.degrees(180.0))
-                        .offset(y: -50)
+                        .offset(y: -80)
                 }
             }
             .navigationBarBackButtonHidden(true)
@@ -104,59 +118,43 @@ struct CardDetailView: View {
     
     @ViewBuilder
     func setHeaderView() -> some View {
-        ZStack(alignment: .top) {
-            HStack {
-                Spacer()
-                
-                Button(action: {
-                    self.presentationMode.wrappedValue.dismiss()
-                }, label: {
-                    Image("Close")
+        if motionMode == .top {
+            VStack(spacing: 0) {
+                if !motionManager.isDeviceFlipped {
+                    Image("Arrow")
                         .resizable()
                         .scaledToFit()
-                        .frame(width: 35, height: 35)
-                })
-                .padding(.trailing, 23)
-            }
-            
-            if motionMode == .top {
-                VStack(spacing: 0) {
-                    if !motionManager.isDeviceFlipped {
-                        Image("Arrow")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 106, height: 155)
-
-                        Group {
-                            Text("고개를")
-                                .font(.system(size: 18, weight: .regular))
-                            + Text(" 들어서")
-                                .font(.system(size: 18, weight: .bold))
-                            + Text(" 내용을 확인")
-                                .font(.system(size: 18, weight: .regular))
-                        }
-                        .foregroundStyle(.white)
-                        .offset(y: 24)
-                    }
-                }
-            } else {
-                VStack(spacing: 0) {
-                    Image(motionMode == .left ? "leftArrow" : "rightArrow")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 184, height: 95)
+                        .frame(width: 106, height: 155)
+                    
                     Group {
                         Text("고개를")
                             .font(.system(size: 18, weight: .regular))
-                        + Text(" 꺽어서")
+                        + Text(" 들어서")
                             .font(.system(size: 18, weight: .bold))
-                        + Text((motionMode == .left && motionManager.xAcceleration < -0.15) || motionMode == .right && motionManager.xAcceleration > 0.15 ? " 제목으로 돌아가기" :" 내용을 확인")
+                        + Text(" 내용을 확인")
                             .font(.system(size: 18, weight: .regular))
                     }
                     .foregroundStyle(.white)
-                    .padding(.top, 44)
                     .offset(y: 24)
                 }
+            }
+        } else {
+            VStack(spacing: 0) {
+                Image(motionMode == .left ? "leftArrow" : "rightArrow")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 184, height: 95)
+                Group {
+                    Text("고개를")
+                        .font(.system(size: 18, weight: .regular))
+                    + Text(" 꺽어서")
+                        .font(.system(size: 18, weight: .bold))
+                    + Text((motionMode == .left && motionManager.xAcceleration < -0.15) || motionMode == .right && motionManager.xAcceleration > 0.15 ? " 제목으로 돌아가기" :" 내용을 확인")
+                        .font(.system(size: 18, weight: .regular))
+                }
+                .foregroundStyle(.white)
+                .padding(.top, 44)
+                .offset(y: 24)
             }
         }
     }

--- a/WorkUp/WorkUp/View/CardDetail/CardDetailView.swift
+++ b/WorkUp/WorkUp/View/CardDetail/CardDetailView.swift
@@ -19,7 +19,6 @@ struct CardDetailView: View {
     @State var quizModel: String = "나는 누굴까요?"
     @State private var showAlert = false
     @State var currentIndex = 0
-    @State var isLastQuiz = false
     @State private var dragOffset: CGSize = .zero // 드래그 오프셋 상태 변수
     @State private var scrollId: Int? = 0
     @State var motionMode: MotionMode = .top
@@ -33,22 +32,9 @@ struct CardDetailView: View {
                 .ignoresSafeArea(.all)
             
             VStack(spacing: 0) {
-                HStack {
-                    Spacer()
-                    
-                    Button(action: {
-                        self.presentationMode.wrappedValue.dismiss()
-                    }, label: {
-                        Image(isLastQuiz ? "Activeclose" : "Close")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 35, height: 35)
-                    })
-                    .padding(.trailing, 23)
-                }
                 
                 setHeaderView()
-                
+
                 GeometryReader { geo in
                     ScrollView(.horizontal, showsIndicators: false) {
                         LazyHStack(spacing: 0) {
@@ -57,11 +43,11 @@ struct CardDetailView: View {
                                     RollMotionCardView(motionManager: motionManager, currentIndex: $currentIndex, shuffledCardList: shuffledCardList)
                                        
                                 } else {
-                                    YawMotionCardView(motionManager: motionManager, motionMode: $motionMode, currentIndex: $currentIndex, shuffledCardList: shuffledCardList)
-                                        .padding(.top, 21.75)
+                                    YawMotionCardView(motionManager: motionManager, currentIndex: $currentIndex, shuffledCardList: shuffledCardList, isLeft: motionMode == .left ? true : false)
                                 }
                             }
                             .frame(width: 315, height: 424)
+                            .padding(.bottom, 50)
                             .padding(.horizontal, (geo.size.width - 315) / 2)
                             .scrollTransition(.interactive, axis: .horizontal) { content, phase in
                                 content
@@ -83,7 +69,7 @@ struct CardDetailView: View {
                     .scrollDisabled(motionManager.isDeviceFlipped ? true : false)
                     .scrollDisabled(motionManager.isYawRotated ? true : false)
                 }
-                
+               
                 if motionMode == .top && motionManager.isDeviceFlipped && !motionManager.isDeviceFlippedFor5Seconds {
                     VStack(spacing: 0) {
                         Text("내용 확인하기")
@@ -106,40 +92,40 @@ struct CardDetailView: View {
                         .padding(.top, 52)
                 }
             }
+
             .navigationBarBackButtonHidden(true)
             .ignoresSafeArea(.all, edges: .bottom)
             .onAppear {
-                if shuffledCardList.count == 1{
-                    isLastQuiz = true
-                }
-                
-                
+                shuffledCardList = getShuffledCardList()
             }
-        }
-        .onAppear {
-            shuffledCardList = getShuffledCardList()
         }
     }
     
     @ViewBuilder
     func setHeaderView() -> some View {
-        if motionMode == .top {
-            VStack(spacing: 0) {
-                if !motionManager.isDeviceFlipped {
-                    Image("Arrow")
+        ZStack(alignment: .top) {
+            HStack {
+                Spacer()
+                
+                Button(action: {
+                    self.presentationMode.wrappedValue.dismiss()
+                }, label: {
+                    Image("Close")
                         .resizable()
                         .scaledToFit()
-                        .frame(width: 106, height: 155)
-                        .background {
-                            Color.clear
-                        }
-                        .padding(.bottom, 20)
-                    
-                    if isLastQuiz {
-                        Text("모든 카드가 끝났습니다")
-                            .foregroundStyle(isLastQuiz ? Color("MainColor") :.white)
-                            .padding(.bottom, 20)
-                    } else {
+                        .frame(width: 35, height: 35)
+                })
+                .padding(.trailing, 23)
+            }
+            
+            if motionMode == .top {
+                VStack(spacing: 0) {
+                    if !motionManager.isDeviceFlipped {
+                        Image("Arrow")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 106, height: 155)
+
                         Group {
                             Text("고개를")
                                 .font(.system(size: 18, weight: .regular))
@@ -148,28 +134,28 @@ struct CardDetailView: View {
                             + Text(" 내용을 확인")
                                 .font(.system(size: 18, weight: .regular))
                         }
-                        .foregroundStyle(isLastQuiz ? Color("MainColor") :.white)
-                        .padding(.bottom, 20)
+                        .foregroundStyle(.white)
+                        .offset(y: 24)
                     }
                 }
-            }
-        } else {
-            VStack(spacing: 0) {
-                Image(motionMode == .left ? "leftArrow" : "rightArrow")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 177, height: 95)
-                    .padding(.bottom, 15.82)
-                Group {
-                    Text("고개를")
-                        .font(.system(size: 18, weight: .regular))
-                    + Text(" 꺽어서")
-                        .font(.system(size: 18, weight: .bold))
-                    + Text((motionMode == .left && motionManager.xAcceleration < -0.15) || motionMode == .right && motionManager.xAcceleration > 0.15 ? " 제목으로 돌아가기" :" 내용을 확인")
-                        .font(.system(size: 18, weight: .regular))
+            } else {
+                VStack(spacing: 0) {
+                    Image(motionMode == .left ? "leftArrow" : "rightArrow")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 184, height: 95)
+                    Group {
+                        Text("고개를")
+                            .font(.system(size: 18, weight: .regular))
+                        + Text(" 꺽어서")
+                            .font(.system(size: 18, weight: .bold))
+                        + Text((motionMode == .left && motionManager.xAcceleration < -0.15) || motionMode == .right && motionManager.xAcceleration > 0.15 ? " 제목으로 돌아가기" :" 내용을 확인")
+                            .font(.system(size: 18, weight: .regular))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.top, 44)
+                    .offset(y: 24)
                 }
-                .foregroundStyle(.white)
-                .padding(.top, 44.4)
             }
         }
     }

--- a/WorkUp/WorkUp/View/CardDetail/CardDetailView.swift
+++ b/WorkUp/WorkUp/View/CardDetail/CardDetailView.swift
@@ -34,7 +34,7 @@ struct CardDetailView: View {
             VStack(spacing: 0) {
                 
                 setHeaderView()
-
+                
                 GeometryReader { geo in
                     ScrollView(.horizontal, showsIndicators: false) {
                         LazyHStack(spacing: 0) {
@@ -69,6 +69,7 @@ struct CardDetailView: View {
                     .scrollDisabled(motionManager.isDeviceFlipped ? true : false)
                     .scrollDisabled(motionManager.isYawRotated ? true : false)
                 }
+
                
                 if motionMode == .top && motionManager.isDeviceFlipped && !motionManager.isDeviceFlippedFor5Seconds {
                     VStack(spacing: 0) {
@@ -80,7 +81,7 @@ struct CardDetailView: View {
                             .multilineTextAlignment(.center)
                             .padding(.top, 19)
                     }
-                    .padding(.bottom, 50)
+                    .offset(y: -50)
                     
                 } else if motionMode == .top && motionManager.isDeviceFlipped && motionManager.isDeviceFlippedFor5Seconds {
                     
@@ -89,14 +90,14 @@ struct CardDetailView: View {
                         .scaledToFit()
                         .frame(width: 106, height: 155)
                         .rotationEffect(.degrees(180.0))
-                        .padding(.top, 52)
+                        .offset(y: -50)
                 }
             }
-
             .navigationBarBackButtonHidden(true)
             .ignoresSafeArea(.all, edges: .bottom)
             .onAppear {
                 shuffledCardList = getShuffledCardList()
+                randomMode()
             }
         }
     }

--- a/WorkUp/WorkUp/View/CardDetail/CardDetailView.swift
+++ b/WorkUp/WorkUp/View/CardDetail/CardDetailView.swift
@@ -20,10 +20,10 @@ struct CardDetailView: View {
     @State private var showAlert = false
     @State var currentIndex = 0
     @State var isLastQuiz = false
-    var shuffledCardList: [NewCard] = Array(repeating: NewCard(question: "", answer: ""), count: 100)
     @State private var dragOffset: CGSize = .zero // 드래그 오프셋 상태 변수
     @State private var scrollId: Int? = 0
     @State var motionMode: MotionMode = .top
+    @State var shuffledCardList: [NewCard] = []
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -117,6 +117,9 @@ struct CardDetailView: View {
                 
             }
         }
+        .onAppear {
+            shuffledCardList = getShuffledCardList()
+        }
     }
     
     @ViewBuilder
@@ -176,6 +179,14 @@ struct CardDetailView: View {
         motionMode = MotionMode.allCases.randomElement()!
     }
     
+    private func getShuffledCardList() -> [NewCard] {
+        var newShuffledCardList: [NewCard] = []
+        newCards.forEach { card in
+            newShuffledCardList.append(card)
+        }
+        newShuffledCardList.shuffle()
+        return newShuffledCardList
+    }
 }
 
 #Preview {

--- a/WorkUp/WorkUp/View/CardDetail/CardDetailView.swift
+++ b/WorkUp/WorkUp/View/CardDetail/CardDetailView.swift
@@ -55,15 +55,14 @@ struct CardDetailView: View {
                             ForEach(shuffledCardList.indices, id: \.self) { idx in
                                 if motionMode == .top {
                                     RollMotionCardView(motionManager: motionManager, currentIndex: $currentIndex, shuffledCardList: shuffledCardList)
-                                        .frame(width: 315, height: 424)
+                                       
                                 } else {
                                     YawMotionCardView(motionManager: motionManager, motionMode: $motionMode, currentIndex: $currentIndex, shuffledCardList: shuffledCardList)
-                                        .frame(width: 315, height: 424)
                                         .padding(.top, 21.75)
                                 }
                             }
-                            .offset(x: -20)
-                            .safeAreaPadding(.horizontal, 60)
+                            .frame(width: 315, height: 424)
+                            .padding(.horizontal, (geo.size.width - 315) / 2)
                             .scrollTransition(.interactive, axis: .horizontal) { content, phase in
                                 content
                                     .opacity(phase.isIdentity ? 1 : 0.6)
@@ -71,9 +70,10 @@ struct CardDetailView: View {
                                 
                             }
                         }
+                        // lazyHStack
                         .scrollTargetLayout()
                     }
-                    .scrollTargetBehavior(.viewAligned)
+                    .scrollTargetBehavior(.paging)
                     .scrollPosition(id: $scrollId)
                     .onChange(of: scrollId) { oldValue, newValue in
                         guard let newValue else { return }
@@ -83,7 +83,6 @@ struct CardDetailView: View {
                     .scrollDisabled(motionManager.isDeviceFlipped ? true : false)
                     .scrollDisabled(motionManager.isYawRotated ? true : false)
                 }
-//                .padding(.top, motionManager.isDeviceFlipped ? 60 : 20)
                 
                 if motionMode == .top && motionManager.isDeviceFlipped && !motionManager.isDeviceFlippedFor5Seconds {
                     VStack(spacing: 0) {
@@ -166,7 +165,7 @@ struct CardDetailView: View {
                         .font(.system(size: 18, weight: .regular))
                     + Text(" 꺽어서")
                         .font(.system(size: 18, weight: .bold))
-                    + Text((motionMode == .left && motionManager.xAcceleration < -0.15) || motionMode == .right && motionManager.xAcceleration > 0.15 ? "제목으로 돌아가기" :" 내용을 확인")
+                    + Text((motionMode == .left && motionManager.xAcceleration < -0.15) || motionMode == .right && motionManager.xAcceleration > 0.15 ? " 제목으로 돌아가기" :" 내용을 확인")
                         .font(.system(size: 18, weight: .regular))
                 }
                 .foregroundStyle(.white)

--- a/WorkUp/WorkUp/View/CardDetail/RollMotionCard/RollMotionCardView.swift
+++ b/WorkUp/WorkUp/View/CardDetail/RollMotionCard/RollMotionCardView.swift
@@ -29,7 +29,7 @@ struct RollMotionCardView: View {
             if motionManager.isDeviceFlipped && !motionManager.isDeviceFlippedFor5Seconds{
                 ProgressRingView(progress: $motionManager.timeIntervalSince)
             } else if motionManager.isDeviceFlipped && motionManager.isDeviceFlippedFor5Seconds{
-                CardContentView(isAnswer: true, content: shuffledCardList[currentIndex].question, index: currentIndex, totalNum: shuffledCardList.count)
+                CardContentView(isAnswer: true, content: shuffledCardList[currentIndex].answer, index: currentIndex, totalNum: shuffledCardList.count)
             } else {
                 CardContentView(content: shuffledCardList[currentIndex].question, index: currentIndex, totalNum: shuffledCardList.count)
             }

--- a/WorkUp/WorkUp/View/CardDetail/YawMotionCard/YawMotionCardView.swift
+++ b/WorkUp/WorkUp/View/CardDetail/YawMotionCard/YawMotionCardView.swift
@@ -9,10 +9,9 @@ import SwiftUI
 
 struct YawMotionCardView: View {
     @ObservedObject var motionManager: MotionManager
-    @Binding var motionMode: MotionMode
     @Binding var currentIndex: Int
     @State var shuffledCardList: [NewCard]
-    @State var isLeft = true
+    var isLeft: Bool
 
     var rotationAngle: Double {
         let maxAngle = isLeft ? -25.0 : 25.0
@@ -38,13 +37,6 @@ struct YawMotionCardView: View {
             questionCard
                 .opacity(abs(rotationAngle) > 5 ? 1 : 0.3)
                 .animation(.easeInOut, value: motionManager.xAcceleration)
-        }
-        .onChange(of: motionMode) {
-            if motionMode == .left {
-                isLeft = true
-            } else {
-                isLeft = false
-            }
         }
     }
     

--- a/WorkUp/WorkUp/View/Main/MainCardView.swift
+++ b/WorkUp/WorkUp/View/Main/MainCardView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct MainCardView: View {
-    var shuffledCardList: [NewCard] = []
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 13)
@@ -33,7 +32,7 @@ struct MainCardView: View {
                 Image("MainCardImage")
                 
                 NavigationLink {
-                    CardDetailView(shuffledCardList: shuffledCardList)
+                    CardDetailView()
                 } label: {
                     RoundedRectangle(cornerRadius: 12)
                         .fill(Color.main)

--- a/WorkUp/WorkUp/View/Main/MainView.swift
+++ b/WorkUp/WorkUp/View/Main/MainView.swift
@@ -43,22 +43,13 @@ struct MainView: View {
                     if newCards.isEmpty {
                         EmptyCardView()
                     }else {
-                        MainCardView(shuffledCardList: shuffledCardList())
+                        MainCardView()
                     }
                     Spacer()
                 }
                 
             }
         }
-    }
-    
-    private func shuffledCardList() -> [NewCard] {
-        var newShuffledCardList: [NewCard] = []
-        newCards.forEach { card in
-            newShuffledCardList.append(card)
-        }
-        newShuffledCardList.shuffle()
-        return newShuffledCardList
     }
 }
 

--- a/WorkUp/WorkUp/View/NewCard/NewCardView.swift
+++ b/WorkUp/WorkUp/View/NewCard/NewCardView.swift
@@ -30,6 +30,9 @@ struct NewCardView: View {
             
             ScrollView {
                 VStack {
+                    Spacer()
+                        .frame(height: 35)
+                    
                     VStack(alignment:.leading) {
                         VStack(alignment: .leading, spacing: 15){
                             Text("카드를")

--- a/WorkUp/WorkUp/View/NewCard/NewCardView.swift
+++ b/WorkUp/WorkUp/View/NewCard/NewCardView.swift
@@ -27,45 +27,89 @@ struct NewCardView: View {
         
         ZStack{
             Color.black.edgesIgnoringSafeArea(.all)
-                 
-            VStack {
-                Spacer()
-                    .frame(height: 125)
-                VStack(alignment:.leading) {
-                    VStack(alignment: .leading, spacing: 15){
-                        Text("카드를")
-                            .foregroundColor(buttonColor)
-                            .font(.system(size: 40))
-                            .fontWeight(.bold)
-                        Text("만들어주세요!")
-                            .foregroundColor(.white)
-                            .font(.system(size: 40))
-                            .fontWeight(.bold)
-                    } 
-                   
-                    Spacer()
-                        .frame(height: 38)
-                    
-                    VStack{
-                        HStack {
-                            Text("카드")
-                                .foregroundColor(textlabelColor)
-                                .font(.system(size: 20))
-                                .fontWeight(.bold)
-                            + Text("제목")
+            
+            ScrollView {
+                VStack {
+                    VStack(alignment:.leading) {
+                        VStack(alignment: .leading, spacing: 15){
+                            Text("카드를")
                                 .foregroundColor(buttonColor)
-                                .font(.system(size: 20))
+                                .font(.system(size: 40))
                                 .fontWeight(.bold)
-                            Spacer()
-                            Text("\(question.count) / \(limitCount)자")
-                                .font(.system(size: 15))
-                        }.padding(.leading, 10)
+                            Text("만들어주세요!")
+                                .foregroundColor(.white)
+                                .font(.system(size: 40))
+                                .fontWeight(.bold)
+                        }
+                       
+                        Spacer()
+                            .frame(height: 38)
                         
-                        ZStack(alignment: .topLeading) {
-                            let placeholder: String = "문제를 입력해 주세요"
+                        VStack{
+                            HStack {
+                                Text("카드")
+                                    .foregroundColor(textlabelColor)
+                                    .font(.system(size: 20))
+                                    .fontWeight(.bold)
+                                + Text("제목")
+                                    .foregroundColor(buttonColor)
+                                    .font(.system(size: 20))
+                                    .fontWeight(.bold)
+                                Spacer()
+                                Text("\(question.count) / \(limitCount)자")
+                                    .font(.system(size: 15))
+                            }.padding(.leading, 10)
                             
-                            TextEditor(text: $question)
-                                .maxLength(text: $question, limitCount)
+                            ZStack(alignment: .topLeading) {
+                                let placeholder: String = "문제를 입력해 주세요"
+                                
+                                TextEditor(text: $question)
+                                    .maxLength(text: $question, limitCount)
+                                    .font(.system(size: 15))
+                                    .scrollContentBackground(.hidden)
+                                    .foregroundColor(.white)
+                                    .padding(.leading, 10)
+                                    .padding(.top, 11)
+                                    .background(textfieldColor)
+                                    .frame(width: 310, height: 148)
+                                    .cornerRadius(10)
+                                    .lineSpacing(10.0)
+                                
+                                if question.isEmpty {
+                                    Text(placeholder)
+                                        .font(.system(size: 15))
+                                        .foregroundColor(placeholderColor)
+                                        .padding(.leading, 15)
+                                        .padding(.top, 21)
+                                }
+                            }
+                           
+                        }
+                        
+                        Spacer()
+                            .frame(height: 23)
+                        
+                        VStack {
+                            HStack {
+                                Text("카드")
+                                    .foregroundColor(textlabelColor)
+                                    .font(.system(size: 20))
+                                    .fontWeight(.bold)
+                                + Text("내용")
+                                    .foregroundColor(buttonColor)
+                                    .font(.system(size: 20))
+                                    .fontWeight(.bold)
+                                
+                                Spacer()
+                                Text("\(answer.count) / \(limitCount)자")
+                                    .font(.system(size: 15))
+                            }
+                            .padding(.leading, 10)
+                            ZStack(alignment: .topLeading) {
+                                let placeholder: String = "내용을 작성해 주세요 \n무엇을 기억하고 싶나요?"
+                            
+                            TextEditor(text: $answer)
+                                .maxLength(text: $answer, limitCount)
                                 .font(.system(size: 15))
                                 .scrollContentBackground(.hidden)
                                 .foregroundColor(.white)
@@ -75,8 +119,8 @@ struct NewCardView: View {
                                 .frame(width: 310, height: 148)
                                 .cornerRadius(10)
                                 .lineSpacing(10.0)
-                            
-                            if question.isEmpty {
+                                
+                            if answer.isEmpty {
                                 Text(placeholder)
                                     .font(.system(size: 15))
                                     .foregroundColor(placeholderColor)
@@ -84,97 +128,54 @@ struct NewCardView: View {
                                     .padding(.top, 21)
                             }
                         }
-                       
+                        }
                     }
+                    .foregroundColor(.white)
+                   
+                    .padding(.horizontal, 40)
                     
                     Spacer()
-                        .frame(height: 23)
+                        .frame(height: 50)
                     
-                    VStack {
-                        HStack {
-                            Text("카드")
-                                .foregroundColor(textlabelColor)
-                                .font(.system(size: 20))
-                                .fontWeight(.bold)
-                            + Text("내용")
-                                .foregroundColor(buttonColor)
-                                .font(.system(size: 20))
-                                .fontWeight(.bold)
-                            
-                            Spacer()
-                            Text("\(answer.count) / \(limitCount)자")
-                                .font(.system(size: 15))
+                    Button {
+                        if isEdit {
+                            if let card {
+                                card.question = question
+                                card.answer = answer
+                            }
+                        } else {
+                            let newCard = NewCard(question: question, answer: answer)
+                            modelContext.insert(newCard)
                         }
-                        .padding(.leading, 10)
-                        ZStack(alignment: .topLeading) {
-                            let placeholder: String = "내용을 작성해 주세요 \n무엇을 기억하고 싶나요?"
-                        
-                        TextEditor(text: $answer)
-                            .maxLength(text: $answer, limitCount)
-                            .font(.system(size: 15))
-                            .scrollContentBackground(.hidden)
-                            .foregroundColor(.white)
-                            .padding(.leading, 10)
-                            .padding(.top, 11)
-                            .background(textfieldColor)
-                            .frame(width: 310, height: 148)
+                        dismiss()
+                    } label: {
+                        Text(isEdit ? "카드 수정하기" : "카드 만들기")
+                            .fontWeight(.semibold)
+                            .frame(width: 354, height: 64)
+                            .background(buttonColor)
+                            .foregroundColor(.black)
                             .cornerRadius(10)
-                            .lineSpacing(10.0)
-                            
-                        if answer.isEmpty {
-                            Text(placeholder)
-                                .font(.system(size: 15))
-                                .foregroundColor(placeholderColor)
-                                .padding(.leading, 15)
-                                .padding(.top, 21)
-                        }
+                            .font(.system(size: 20))
                     }
-                    }
+                    .padding(.vertical, 22)
+                    .disabled(question.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .disabled(answer.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .navigationBarBackButtonHidden(true)
+                    .navigationBarItems(leading: Button(action: {
+                                dismiss()
+                            }) {
+                                Image(systemName: "chevron.left")
+                                    .foregroundColor(.white) // Custom back button color
+                            })
+                    Spacer()
+                        .frame(height: 50)
+                    
                 }
-                .foregroundColor(.white)
-               
-                .padding(.horizontal, 40)
-                
-                Spacer()
-                    .frame(height: 50)
-                
-                Button {
-                    if isEdit {
-                        if let card {
-                            card.question = question
-                            card.answer = answer
-                        }
-                    } else {
-                        let newCard = NewCard(question: question, answer: answer)
-                        modelContext.insert(newCard)
-                    }
-                    dismiss()
-                } label: {
-                    Text(isEdit ? "카드 수정하기" : "카드 만들기")
-                        .fontWeight(.semibold)
-                        .frame(width: 354, height: 64)
-                        .background(buttonColor)
-                        .foregroundColor(.black)
-                        .cornerRadius(10)
-                        .font(.system(size: 20))
-                } 
-                .padding(.vertical, 22)
-                .disabled(question.trimmingCharacters(in: .whitespaces).isEmpty)
-                .disabled(answer.trimmingCharacters(in: .whitespaces).isEmpty)
-                .navigationBarBackButtonHidden(true)
-                .navigationBarItems(leading: Button(action: {
-                            dismiss()
-                        }) {
-                            Image(systemName: "chevron.left")
-                                .foregroundColor(.white) // Custom back button color
-                        })
-                Spacer()
-                    .frame(height: 50)
-                
+                .onTapGesture {
+                    hideKeyboard()
+                }
             }
-            .onTapGesture {
-                hideKeyboard()
-            }
+            .scrollIndicators(.hidden)
         }
     }
 }


### PR DESCRIPTION
## 🔥 작업한 내용
- 메인뷰에서 @query로 가져온 카드를 셔플해서 하위 뷰로 넘겨주어 CardDetailView까지 전달을 했는데
어차피 CardDetailView에서 카드를 @query 로 가져오고 있어 해당 프로퍼티들을 제거
- .padding(.horizontal, (geo.size.width - 315) / 2)을 ForEach에 추가함으로써 카드가 LazyHStack의 가운데에 오도록 패딩을 추가하고
- 기존에 ScrollTargetBehavior를 viewAligned에서 paging으로 변경, viewAligned로 설정시 스크롤 자유도가 생겨 페이징이 제대로 되지 않음
- CardDetailView에서 motionMode에 따라 YawMotionCardView 의 뷰가 결정되는데 기존에 onChange로 변화를 감지하게 되어있어서 두 뷰 간의 값의 동기화 오류가 있었음
- YawMotionCardView에서 motionMode에 뷰 초기화 시 변수로 isLeft값을 motionMode에 따라 받아서 YawMotionCardView를 그리도록 수정하여 동기화 오류 해결

### 카드 생성 뷰
- VStack에서 상단 Spacer를 빼고 ScrollView 를 추가

## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #16 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
